### PR TITLE
Maybe this will help?

### DIFF
--- a/code/MyConditionalPrior.cpp
+++ b/code/MyConditionalPrior.cpp
@@ -3,7 +3,7 @@
 #include "Data.h"
 #include <cmath>
 #include <gsl/gsl_cdf.h>
-
+#include <iostream>
 using namespace DNest4;
 
 MyConditionalPrior::MyConditionalPrior(double x_min, double x_max, 
@@ -20,12 +20,30 @@ MyConditionalPrior::MyConditionalPrior(double x_min, double x_max,
 
 void MyConditionalPrior::from_prior(RNG& rng)
 {
-	mu = tan(M_PI*(0.97*rng.rand() - 0.485)); // mean amplitude 
-	mu = exp(mu);
-	mu_widths = exp(log(0.33*0.983) + (log(5*0.983) - log(0.1*0.983))*rng.rand()); // mean risetime hardcoded with CHIME time resolution 983 us (CHIME data is in ms)
+//	mu = tan(M_PI*(0.97*rng.rand() - 0.485)); // mean amplitude 
+//	mu = exp(mu);
+//	mu_widths = exp(log(0.33*0.983) + (log(5*0.983) - log(0.33*0.983))*rng.rand()); // mean risetime hardcoded with CHIME time resolution 983 us (CHIME data is in ms)
 
-	sig = 2.*rng.rand(); // width amplitude
-	sig_widths = 2.*rng.rand(); // width risetime
+//	sig = 2.*rng.rand(); // width amplitude
+//	sig_widths = 2.*rng.rand(); // width risetime
+
+        const DNest4::Cauchy cauchy_mu(1.0, 2.0);
+        do
+        {
+            mu = cauchy_mu.generate(rng);
+        }while(mu >= 5.5 || mu <= - 2.3);
+        mu = exp(mu);
+
+        const DNest4::Cauchy cauchy_width(0.0, 1.0);
+        do
+        {
+             mu_widths = cauchy_width.generate(rng);
+        }while(mu_widths >= 2.3 || mu_widths <= -1.1);
+        mu_widths = exp(mu_widths);
+
+
+        sig = exp(-2 + 2.5*rng.rand());
+        sig_widths = exp(-2 + 2.*rng.rand());
 
 	a = -5. + 10.*rng.rand(); // mean skewness
 	b = 2.5*rng.rand(); // width skewness 
@@ -39,34 +57,58 @@ double MyConditionalPrior::perturb_hyperparameters(RNG& rng)
 
 	if(which == 0)
 	{
-		mu = log(mu);
-		mu = (atan(mu)/M_PI + 0.485)/0.97;
-		mu += pow(10., 1.5 - 6.*rng.rand())*rng.randn();
-		mu = mod(mu, 1.);
-		mu = tan(M_PI*(0.97*mu - 0.485));
-		mu = exp(mu);
+//		mu = log(mu);
+//		mu = (atan(mu)/M_PI + 0.485)/0.97;
+//		mu += pow(10., 1.5 - 6.*rng.rand())*rng.randn();
+//		mu = mod(mu, 1.);
+//		mu = tan(M_PI*(0.97*mu - 0.485));
+//		mu = exp(mu);
+               const DNest4::Cauchy cauchy_mu(1.0, 2.0);
+
+               mu = log(mu);
+               logH += cauchy_mu.perturb(mu, rng);
+               if(mu >= 5.5 || mu <= - 2.3)
+               {
+                   mu=2.0;
+                   return -1E300;
+               }
+               mu = exp(mu);
 	}
 	if(which == 1)
-	{ 
-	//	mu_widths = log(mu_widths/());
-	//	mu_widths += log(10*0.983)*pow(10., 1.5 - 6.*rng.rand())*rng.randn(); // hardcoded time resolution
-	//	mu_widths = mod(mu_widths - log(0.1), log(10)) + log(0.1); 
-	//	mu_widths = (0.983)*exp(mu_widths); // hardcoded time resolution
-                mu_widths = log(mu_widths);
-                mu_widths += (log(5*0.983) - log(0.33*0.983))*rng.randh();
-                mu_widths = mod(mu_widths + log(0.33*0.983), log(5*0.983) - log(0.33*0.983)) - log(0.33*0.983);
-                mu_widths = exp(mu_widths); 
+	{  
+//                mu_widths = log(mu_widths);
+//                mu_widths += (log(5*0.983) - log(0.33*0.983))*rng.randh();
+//                mu_widths = mod(mu_widths + log(0.33*0.983), log(5*0.983) - log(0.33*0.983)) - log(0.33*0.983);
+//                mu_widths = exp(mu_widths); 
+               const DNest4::Cauchy cauchy_width(0.0, 1.0);
+
+               mu_widths = log(mu_widths);
+               logH += cauchy_width.perturb(mu_widths, rng);
+               if(mu_widths >= 2.3 || mu_widths <= -1.1)
+               {
+                   mu_widths=1.0;
+                   return -1E300;
+               }
+               mu_widths = exp(mu_widths);
 	}
 	if(which == 2)
 	{
-		sig += 2.*rng.randh();
-		sig = mod(sig, 2.);
+//		sig += 2.*rng.randh();
+//		sig = mod(sig, 2 .);
+                sig = log(sig);
+                sig += 2.5*rng.randh();
+                sig = mod(sig + 2., 2.5) - 2.;
+                sig = exp(sig);
 	}
 	
 	if(which == 3)
-	{
-		sig_widths += 2.*rng.randh();
-		sig_widths = mod(sig_widths, 2.);
+	{ 
+//		sig_widths += 2.*rng.randh();
+//		sig_widths = mod(sig_widths, 2.);
+                sig_widths = log(sig_widths);
+                sig_widths += 2.*rng.randh();
+                sig_widths = mod(sig_widths + 2, 2.0) - 2.0;
+                sig_widths = exp(sig_widths);
 	}
         if(which == 4)
 	{
@@ -84,13 +126,15 @@ double MyConditionalPrior::perturb_hyperparameters(RNG& rng)
 
 double MyConditionalPrior::log_pdf(const std::vector<double>& vec) const
 {
+        //std::cout << min_width << " " << max_width << " " << mu_min << " " << mu_max << std::endl;
+        //std::cout << "amp: " << vec[1] << ", rise: " << vec[2] << std::endl;
 	if(vec[0] < x_min || vec[0] > x_max || vec[1] < 0.0 || vec[2] < min_width
                 || vec[1] < mu_min || vec[1] > mu_max || vec[2] > max_width
 		|| log(vec[3]) < (a-b) || log(vec[3]) > (a + b))
+                //std::cout << "Rejecting component" << std::endl;
 		return -1E300;
 
-//	return -log(mu) - vec[1]/mu - log(mu_widths)
-//			- (vec[2] - min_width)/mu_widths - log(2.*b*vec[3]);
+        //std::cout << "Not rejecting component" << std::endl;
 	return	- log(vec[1]*sig) - 0.5*pow((log(vec[1]) - log(mu))/sig, 2)
 		- log(vec[2]*sig_widths) - 0.5*pow((log(vec[2]) - log(mu_widths))/sig_widths, 2)
 		- log(2.*b*vec[3]);

--- a/code/MyConditionalPrior.h
+++ b/code/MyConditionalPrior.h
@@ -2,6 +2,7 @@
 #define _MyConditionalPrior_
 
 #include "DNest4/code/RJObject/ConditionalPriors/ConditionalPrior.h"
+#include "DNest4/code/DNest4.h"
 
 class MyConditionalPrior:public DNest4::ConditionalPrior
 {


### PR DESCRIPTION
Okay, so, I did a lot of investigations today, and found out a couple of things:
* setting hard limits in the `log_pdf` method in `MyConditionalPrior.cpp` doesn't seem to do anything to restrict the amplitude and rise time to be within those boundaries. I can't figure out why, I might need to ask Brendan (who wrote DNest4)
* I found a way in one of Brendan's example to set truncated Cauchy distributions much better, and I've restricted the hyper priors for the means of the distribution for the rise time and amplitude to be within fairly narrow boundaries
* I think the hyperprior for the hyper parameters defining the width of the log-normal prior for the amplitude and rise time were too wide. I've turned them into log-uniform hyperpriors and narrowed them to the same boundaries as the means
* Together, I think that fixes some of the issues you've been seeing, at least in my initial tests
* setting truncated priors on the amplitude and rise time itself is hard, because truncated distributions have difficult Cumulative Distribution Functions and their inverses (which you need for the `from_uniform` and `to_uniform` methods). I can probably figure that out, but not this week. If narrowing the hyperparameter works well enough, we might not need to
* The only other alternative would be to go back to the exponential prior, because setting lower boundaries on an exponential distribution is easy. 

